### PR TITLE
Fixed crash bug on client disconnect

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -77,7 +77,7 @@ bool Server::Connect(int port)
 bool Server::PollSockets()
 {
     static struct timeval tv;
-
+    Socket* sclose = NULL;
     // copy the permanent descriptor set
     memcpy(&rSet, &fSet, sizeof(fd_set));
 
@@ -92,13 +92,19 @@ bool Server::PollSockets()
     for (Socket* sock: socketList)
         {
 
+            // if previous socket marked for close, then close it
+            if (sclose)
+            {
+                CloseSocket(sclose);
+                sclose = NULL; //reset close pointer
+            }
             // attempt to read from this socket if pending incoming data
             if (FD_ISSET(sock->GetControl(), &rSet))
                 {
 
-                    // if read fails, close the connection
+                    // if read fails, close the connection, after iterater advances
                     if (sock->Read() == false)
-                        CloseSocket(sock);
+                        sclose = sock;
                 }
         }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -104,7 +104,15 @@ bool Server::PollSockets()
 
                     // if read fails, close the connection, after iterater advances
                     if (sock->Read() == false)
-                        sclose = sock;
+                    {
+                        if(sock = socketList.back())
+                        {
+                            CloseSocket(sock);
+                        }
+                        else
+                        {
+                            sclose = sock;
+                        }
                 }
         }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -105,7 +105,7 @@ bool Server::PollSockets()
                     // if read fails, close the connection, after iterater advances
                     if (sock->Read() == false)
                     {
-                        if(sock = socketList.back())
+                        if(sock == socketList.back())
                         {
                             CloseSocket(sock);
                         }


### PR DESCRIPTION
server was crashing on client disconnect because the object pointed to by the iterator was being deleted before advancing the iterator. by waiting to close the socket till the next pass through the loop we can safely delete the dead socket.